### PR TITLE
Add express-ejs-layouts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project provides a simple starting point for building a customizable weddin
 ## Setup
 
 1. Install Node.js (already available in this environment).
-2. Install dependencies:
+2. Install dependencies (includes `express-ejs-layouts`):
    ```bash
    npm install
    ```

--- a/app.js
+++ b/app.js
@@ -8,6 +8,8 @@ const PORT = process.env.PORT || 3000;
 // Set up EJS templating
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
+app.use(require('express-ejs-layouts'));
+app.set('layout', 'layout');
 
 // Static assets
 app.use(express.static(path.join(__dirname, 'public')));

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "body-parser": "^2.2.0",
         "ejs": "^3.1.10",
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "express-ejs-layouts": "^2.5.1"
       }
     },
     "node_modules/accepts": {
@@ -357,6 +358,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-ejs-layouts": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/express-ejs-layouts/-/express-ejs-layouts-2.5.1.tgz",
+      "integrity": "sha512-IXROv9n3xKga7FowT06n1Qn927JR8ZWDn5Dc9CJQoiiaaDqbhW5PDmWShzbpAa2wjWT1vJqaIM1S6vJwwX11gA=="
     },
     "node_modules/filelist": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "body-parser": "^2.2.0",
     "ejs": "^3.1.10",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "express-ejs-layouts": "^2.5.1"
   }
 }


### PR DESCRIPTION
## Summary
- install express-ejs-layouts
- enable express-ejs-layouts middleware and set default layout
- document new dependency in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node app.js` *(server starts then is stopped)*

------
https://chatgpt.com/codex/tasks/task_e_6858e29995e08330b56b77d14f09b6d3