### PR TITLE
Add 404 page and middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ This project provides a simple starting point for building a customizable weddin
 Edit the templates in `views/` to add content such as travel info, registry links, photo galleries, etc. Update `public/style.css` for your own styles.
 
 Feel free to expand this project to include additional features like authentication, guestbook, or email notifications.
+
+Undefined routes show a simple 404 page with a link back home.

--- a/app.js
+++ b/app.js
@@ -35,6 +35,9 @@ app.post('/rsvp', (req, res) => {
   res.render('rsvp-success', { data: req.body });
 });
 
+// 404 handler
+app.use((req, res) => res.status(404).render('404'));
+
 app.listen(PORT, () => {
   console.log(`Wedding website running at http://localhost:${PORT}`);
 });

--- a/views/404.ejs
+++ b/views/404.ejs
@@ -1,0 +1,4 @@
+<% layout('layout', { title: 'Not Found' }) %>
+<h2>Page Not Found</h2>
+<p>The page you're looking for doesn't exist.</p>
+<p><a href="/">Go back home</a></p>


### PR DESCRIPTION
## Summary
- add a 404 template
- document behavior in README
- add catch-all middleware to show the 404 page

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858e41e726c8330b4772d39a9c2d7c9