### PR TITLE
Ensure data directory exists

### DIFF
--- a/rsvpStore.js
+++ b/rsvpStore.js
@@ -4,6 +4,11 @@ const path = require('path');
 const DATA_DIR = path.join(__dirname, 'data');
 const FILE_PATH = path.join(DATA_DIR, 'rsvps.json');
 
+// Ensure the data directory exists before any file operations occur
+if (!fs.existsSync(DATA_DIR)) {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+}
+
 function readRsvps() {
   try {
     const raw = fs.readFileSync(FILE_PATH, 'utf8');


### PR DESCRIPTION
## Summary
- create data dir when rsvpStore loads

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "const store = require('./rsvpStore'); store.addRsvp({name:'Test', email:'test@example.com', attending:true});" && ls -R data`


------
https://chatgpt.com/codex/tasks/task_e_6858e89a12748330ba1547360f417808