### PR TITLE
Add wedding-party and things-to-do pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,14 @@ app.get('/travel', (req, res) => {
   res.render('travel', { title: 'Travel' });
 });
 
+app.get('/wedding-party', (req, res) => {
+  res.render('wedding-party', { title: 'Wedding Party' });
+});
+
+app.get('/things-to-do', (req, res) => {
+  res.render('things-to-do', { title: 'Things to Do' });
+});
+
 app.get('/registry', (req, res) => {
   res.render('registry', { title: 'Registry', extraCss: '/registry.css' });
 });

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -20,6 +20,8 @@
         <li><a href="/">Home</a></li>
         <li><a href="/events">Events</a></li>
         <li><a href="/travel">Travel</a></li>
+        <li><a href="/wedding-party">Wedding Party</a></li>
+        <li><a href="/things-to-do">Things to Do</a></li>
         <li><a href="/registry">Registry</a></li>
         <li><a href="/rsvp">RSVP</a></li>
       </ul>

--- a/views/things-to-do.ejs
+++ b/views/things-to-do.ejs
@@ -1,0 +1,2 @@
+<h2 class="page-heading">Things to Do</h2>
+<p>Local attractions and activities for guests will be listed here.</p>

--- a/views/wedding-party.ejs
+++ b/views/wedding-party.ejs
@@ -1,0 +1,2 @@
+<h2 class="page-heading">Meet the Wedding Party</h2>
+<p>Information about the bridesmaids and groomsmen will go here.</p>


### PR DESCRIPTION
## Summary
- define `/wedding-party` and `/things-to-do` routes
- add matching EJS templates
- update navigation menu

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858f93824108330a896a241614632ca