### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,39 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./docs
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ npm run build
 
 This renders the templates into the `docs/` folder and copies over the assets
 from `public/`. When hosting with GitHub Pages, set the Pages source to the
-`docs/` directory so the generated HTML is served.
+`docs/` directory so the generated HTML is served. The workflow defined in
+`.github/workflows/gh-pages.yml` builds the site and publishes the `docs/`
+folder to GitHub Pages whenever changes are pushed to the `main` branch.
 
 ### Editing templates
 


### PR DESCRIPTION
## Summary
- publish docs folder using GitHub Actions
- explain how Pages is deployed in README

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68598a6566f083309a1511af15185a4e