### PR TITLE
Clarify BASE_URL usage for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ from `public/`. When hosting with GitHub Pages, set the Pages source to the
 `.github/workflows/gh-pages.yml` builds the site and publishes the `docs/`
 folder to GitHub Pages whenever changes are pushed to the `main` branch.
 
+When deploying to `https://<user>.github.io/<repo>/`, set `BASE_URL` to the
+repository name (for example `BASE_URL=/wedding`) so that asset paths resolve
+correctly. You can add this variable to a `.env` file or export it in your shell
+before running `npm run build`.
+
 ### Editing templates
 
 The page layouts live under `views/`. Update these `.ejs` files to change page


### PR DESCRIPTION
## Summary
- document how to set `BASE_URL` for GitHub Pages deployments in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68599531e24c8330a52d766dd22fd1c3